### PR TITLE
Sets the default user-agent for all HTTP requests

### DIFF
--- a/python/getjudo.py
+++ b/python/getjudo.py
@@ -309,7 +309,8 @@ availability_topic = f"{config_getjudo.LOCATION}/{config_getjudo.NAME}/status"
 notification_topic = f"{config_getjudo.LOCATION}/{config_getjudo.NAME}/notify"
 client_id = f"{config_getjudo.NAME}-{config_getjudo.LOCATION}"
 
-http = urllib3.PoolManager()
+user_agent = {'user-agent':'Mozilla'}
+http = urllib3.PoolManager(10, headers=user_agent)
 mydata = savedata()
 
 


### PR DESCRIPTION
It appears that as of 2024-09-16 07:00h CEST, myjudo.eu is blocking requests from scripts. Requests that use a non-browser-like user-agent receive a HTTP 200 status code, but with an empty response body.

Setting a simple user-agent for all HTTP requests circumvents this block. Let's see how far we can get with this.